### PR TITLE
Add files via upload

### DIFF
--- a/Client/overrides/config/charm.cfg
+++ b/Client/overrides/config/charm.cfg
@@ -467,7 +467,7 @@ CharmTweaks {
     B:SpongesReduceFallDamage=true
 
     # Enchanted Books can stack (up to 16).
-    B:StackableEnchantedBooks=true
+    B:StackableEnchantedBooks=false
 
     # Milk buckets can stack (up to 16).
     B:StackableMilkBuckets=true

--- a/Client/overrides/config/cyclicmagic.cfg
+++ b/Client/overrides/config/cyclicmagic.cfg
@@ -628,7 +628,7 @@ cyclicmagic {
         B:AutomaticTorch=false
 
         # placer_block Set false to delete - requires restart [default: true]
-        B:BlockPlacer=true
+        B:BlockPlacer=false
 
         # tool_randomize Set false to delete - requires restart [default: true]
         B:BlockRandomizer=true
@@ -760,7 +760,7 @@ cyclicmagic {
         B:EnderWingPrime=false
 
         # ender_wool Set false to delete - requires restart [default: true]
-        B:EnderWool=true
+        B:EnderWool=false
 
         # entity_detector Set false to delete - requires restart [default: true]
         B:EntityDetector=true

--- a/Client/overrides/config/dimdoors.cfg
+++ b/Client/overrides/config/dimdoors.cfg
@@ -81,7 +81,7 @@ world {
 
     # Min: 0.0
     # Max: 1.0
-    D:clusterGenChance=2.0E-4
+    D:clusterGenChance=0
     I:gatewayDimBlacklist <
      >
 

--- a/Client/overrides/config/erebus.cfg
+++ b/Client/overrides/config/erebus.cfg
@@ -38,7 +38,7 @@ general {
     B:"Dragonflies Grab Players"=true
     I:"Mob Attack Damage Multipier"=2
     I:"Mob Health Multiplier"=2
-    B:"Scorpions Grab Players"=true
+    B:"Scorpions Grab Players"=false
 }
 
 

--- a/Client/overrides/config/extraalchemy.cfg
+++ b/Client/overrides/config/extraalchemy.cfg
@@ -75,7 +75,7 @@ general {
         B:p_hurry=true
         B:p_learning=false
         B:p_leech=true
-        B:p_magnetism=true
+        B:p_magnetism=false
         B:p_pacifism=true
         B:p_pain=true
         B:p_photosynthesis=true

--- a/Client/overrides/config/pitweaks.cfg
+++ b/Client/overrides/config/pitweaks.cfg
@@ -30,10 +30,10 @@ general {
 
     anvil {
         # Allow books to be combined over the enchantment max level
-        B:allowOverlevelBooks=true
+        B:allowOverlevelBooks=false
 
         # Always allow enchantments from books to be applied in an anvil, regardless of item type or other enchantments
-        B:alwaysAllowBooks=true
+        B:alwaysAllowBooks=false
 
         # Removes additional cost from repairing/enchanting items in an anvil multiple times
         B:noRepairCost=true

--- a/Client/overrides/config/quark.cfg
+++ b/Client/overrides/config/quark.cfg
@@ -1036,7 +1036,7 @@ management {
 
 
 misc {
-    B:"Ancient tomes"=true
+    B:"Ancient tomes"=false
     B:"Black ash"=true
     B:"Color runes"=true
     B:"Enderdragon scales"=true
@@ -1050,7 +1050,7 @@ misc {
     B:"Note block interface"=true
     B:"Note blocks play mob sounds if there's a head attached"=true
     B:"Parrot eggs"=true
-    B:Pickarang=true
+    B:Pickarang=false
     B:"Place vanilla dusts"=true
     B:"Poison potato usage"=true
     B:"Reacharound placing"=true

--- a/Client/overrides/config/stackie.cfg
+++ b/Client/overrides/config/stackie.cfg
@@ -43,6 +43,7 @@ general {
         minecraft:tnt_minecart-4
         minecraft:hopper_minecart-4
         minecraft:command_block_minecart-4
+        minecraft:enchanted_book-1
      >
 }
 


### PR DESCRIPTION
Disabled Enchanced Shears (ender wool) due to it being able to crash servers if used on certain betweenlands plant blocks

Dim doors removed random clusters as they had minor performance impact and players kept worrying about them.

Disabled cyclic block placer due to dupe

Disabled extra alchemcy magnetic effect due to dupe

Disabled pickarange due to being able to dupe items

Pitweaks has had unrestricted enchanting disabled due to a dupe 
Enchanted books have been made to stack to only one due to a dupe

Erebus disabled scropion throw due to them being able to launch players 1000 blocks causing instances to crash