### PR TITLE
Mage changes

### DIFF
--- a/Client/overrides/config/apotheosis/enchantments.cfg
+++ b/Client/overrides/config/apotheosis/enchantments.cfg
@@ -1555,7 +1555,7 @@
 
     living {
         # The max level of this enchantment. [range: 1 ~ 127, default: 1]
-        I:"Max Level"=100
+        I:"Max Level"=1
 
         # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
         S:"Max Power Function"=
@@ -2897,7 +2897,7 @@
 
 "tombstone:magic_siphon" {
     # The max level of this enchantment. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=100
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=


### PR DESCRIPTION
Recapped siphon and living
seems that when generated as loots both these enchants will be at there max possible level which was 100