### PR TITLE
More loot table stuff

### DIFF
--- a/Client/overrides/scripts/lootTables/advancedWizardryInject.zs
+++ b/Client/overrides/scripts/lootTables/advancedWizardryInject.zs
@@ -1,0 +1,63 @@
+import loottweaker.LootTweaker;
+import loottweaker.vanilla.loot.LootTable;
+import loottweaker.vanilla.loot.LootPool;
+import loottweaker.vanilla.loot.Conditions;
+import loottweaker.vanilla.loot.Functions;
+
+val lootTableList as string [] = [
+    "dimdoors:dungeon_chest"
+];
+
+for lootTable in lootTableList {
+    val table = LootTweaker.getTable(lootTable);
+    val poolAdvancedWizardInject = table.addPool("poolAdvancedWizardInject", 1, 1, 1, 5);
+    poolAdvancedWizardInject.addEmptyEntry(20, 0);
+    poolAdvancedWizardInject.addItemEntry(<ebwizardry:spell_book>, 10, 0, 
+    [
+        {
+          "ignore_weighting": false,
+          "undiscovered_bias": 0.8,
+          "function": "ebwizardry:random_spell"
+        }
+    ], []);
+    poolAdvancedWizardInject.addItemEntry(<ancientspellcraft:ancient_spellcraft_spell_book>, 2, 0, 
+    [
+        {
+          "ignore_weighting": false,
+          "undiscovered_bias": 0.8,
+          "function": "ebwizardry:random_spell"
+        }
+    ], []);
+    poolAdvancedWizardInject.addItemEntry(<wizardrygolems:golemancy_spell_book>, 2, 0, 
+    [
+        {
+          "ignore_weighting": false,
+          "undiscovered_bias": 0.8,
+          "function": "ebwizardry:random_spell"
+        }
+    ], []);
+    poolAdvancedWizardInject.addItemEntry(<tfspellpack:twilight_spell_book>, 2, 0, 
+    [
+        {
+          "ignore_weighting": false,
+          "undiscovered_bias": 0.8,
+          "function": "ebwizardry:random_spell"
+        }
+    ], []);
+    poolAdvancedWizardInject.addItemEntry(<mospells:mospells_spell_book>, 2, 0, 
+    [
+        {
+          "ignore_weighting": false,
+          "undiscovered_bias": 0.8,
+          "function": "ebwizardry:random_spell"
+        }
+    ], []);
+    poolAdvancedWizardInject.addLootTableEntry("ebwizardry:chests/library_ruins_bookshelf", 15, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ebwizardry:chest/dungeon_additions", 12, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ebwizardry:chests/obelisk", 10, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ebwizardry:chests/wizard_tower", 7, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ancientspellcrat:chest/battlemage_camp", 5, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ancientspellcrat:chest/sage_camp", 5, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ebwizardry:chests/shrine", 3, 0);
+    poolAdvancedWizardInject.addLootTableEntry("ancientspellcrat:chest/ancient_vault", 1, 0);
+}

--- a/Client/overrides/scripts/lootTables/fancyEnchantedBooksInject.zs
+++ b/Client/overrides/scripts/lootTables/fancyEnchantedBooksInject.zs
@@ -1,0 +1,24 @@
+import loottweaker.LootTweaker;
+import loottweaker.vanilla.loot.LootTable;
+import loottweaker.vanilla.loot.LootPool;
+import loottweaker.vanilla.loot.Conditions;
+import loottweaker.vanilla.loot.Functions;
+
+val lootTableList as string [] = [
+    "dimdoors:dungeon_chest"
+];
+
+for lootTable in lootTableList {
+    val table = LootTweaker.getTable(lootTable);
+    val poolFancyEnchantedBooks = table.addPool("poolFancyEnchantedBooks", 1, 1, 1, 5);
+    poolFancyEnchantedBooks.addEmptyEntry(15, 0);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 40, 0, [Functions.enchantWithLevels(0, 30, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 25, 0, [Functions.enchantWithLevels(0, 80, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 15, 0, [Functions.enchantWithLevels(0, 150, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 10, 0, [Functions.enchantWithLevels(30, 30, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 7, 0, [Functions.enchantWithLevels(60, 60, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 5, 0, [Functions.enchantWithLevels(90, 90, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 3, 0, [Functions.enchantWithLevels(120, 120, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 1, 0, [Functions.enchantWithLevels(150, 150, true)], []);
+    poolFancyEnchantedBooks.addItemEntry(<minecraft:book>, 4, 0, [Functions.enchantWithLevels(0, 300, true)], []);
+}

--- a/Client/overrides/scripts/lootTables/livingBookInject.zs
+++ b/Client/overrides/scripts/lootTables/livingBookInject.zs
@@ -1,0 +1,14 @@
+import loottweaker.LootTweaker;
+import loottweaker.vanilla.loot.LootTable;
+import loottweaker.vanilla.loot.LootPool;
+import loottweaker.vanilla.loot.Conditions;
+import loottweaker.vanilla.loot.Functions;
+import crafttweaker.enchantments.IEnchantmentDefinition;
+import crafttweaker.data.IData;
+
+val livingEnchantId = <enchantment:livingenchantment:enchantment.living>.id;
+
+val lootDimDoorsChest = LootTweaker.getTable("dimdoors:dungeon_chest");
+val poolEnchantedBooks = lootDimDoorsChest.addPool("livingEnchantPool", 1, 1, 0, 10);
+poolEnchantedBooks.addItemEntry(<minecraft:enchanted_book>.withTag({StoredEnchantments: [{lvl: 1 as short, id: livingEnchantId}]}), 1);
+poolEnchantedBooks.addEmptyEntry(19);


### PR DESCRIPTION
The following 2 scripts are set up so that you can add additional loot table by extending the list of loot tables in the file
fancyEnchantedBookInject.zs 
advancedWizardryInject.zs

The wizardry inject randomly adds wizardry spell books (increased rat of undiscovered), or one of multiple random wizardry related loot table to the table in question also has a chance to add nothing to a particular opening of a chest.

the enchanted book inject adds enchanted books in a variety of levels from 0 all the way to 150 (higher of course being rarer).